### PR TITLE
Retrieve author of tags properly

### DIFF
--- a/git-notifier
+++ b/git-notifier
@@ -349,7 +349,7 @@ def generateMailHeader(subject, rev=None):
 
     if not sender:
         if rev:
-            sender = "".join(git("show '--pretty=format:%%cn <%%ce>' -s %s" % rev))
+            sender = "".join(git("show '--pretty=format:%%cn <%%ce>' -s %s^{commit}" % rev))
         else:
             sender = whoami
 


### PR DESCRIPTION
`git show` always returns the tag description and other stuff for
tag objects (and this unfortunately is not suppressed by the -s we
already pass) -- which is then all written to the From: header,
totally garbling it.

However, one can explicitly request git to show the commit that is
referenced by the object designated by the revision hash. For tags,
this does exactly what we want, and for normal commits it's a no-op.
