### PR TITLE
Fix for issue #5 (transfer UTF-8 encoded body as quoted-printable)

### DIFF
--- a/git-notifier
+++ b/git-notifier
@@ -3,6 +3,7 @@
 import getpass
 import optparse
 import os
+import quopri
 import shutil
 import socket
 import subprocess
@@ -362,6 +363,8 @@ def generateMailHeader(subject, rev=None):
     print >>out, """From: %s
 To: %s
 Subject: %s %s
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
 %s%sX-Git-Repository: %s
 X-Mailer: %s %s
 
@@ -377,14 +380,19 @@ X-Mailer: %s %s
 def sendMail(out, fname):
     out.close()
 
+    body = False
     if Config.debug:
         for line in open(fname):
-            print "    |", line,
+            if not body and not line.rstrip():
+                body = True
+            print "    |", quopri.encodestring(line) if body else line,
         print ""
     else:
         stdin = subprocess.Popen("/usr/sbin/sendmail -t", shell=True, stdin=subprocess.PIPE).stdin
         for line in open(fname):
-            print >>stdin, line,
+            if not body and not line.rstrip():
+                body = True
+            print >>stdin, quopri.encodestring(line) if body else line,
         stdin.close()
 
     # Wait a bit in case we're going to send more mails. Otherwise, the mails


### PR DESCRIPTION
This turns the example I gave in the issue into:

diff --git a/file b/file
new file mode 100644
index 0000000..8874d5e
--- /dev/null
+++ b/file
@@ -0,0 +1 @@
+=C4=9B=C5=A1=C4=8D=C5=99=C5=BE=C3=BD=C3=A1=C3=AD=C3=A9

which worked fine with Thunderbird and Lotus Notes (if anybody cares :-) )
