### PR TITLE
Added config file support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*.sw?
 test-repo.git
 *.tar.gz
 README.html

--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,9 @@ Usage
 -----
 
 ``git-notifier`` supports the options below. Alternatively to
-giving them on the command line, all of them can alse be set via
+giving them on the command line, all of them can alse be set by
+editing ``git-notifier.conf``. Configuration values in this file
+can be overridden on a per-repo basis via
 ``git config hooks.<option>``. For example, to set a recipient
 address, do ``git config hooks.mailinglist git-updates@foo.com``:
 

--- a/git-notifier
+++ b/git-notifier
@@ -65,6 +65,7 @@ Options = [
     ("mailsubjectlen", True, None, "limit the length of mail subjects (number of chars)"),
     ("noupdate", False, False, "do not update the state file"),
     ("repouri", True, None, "full URI for the repository"),
+    ("gitbasedir", True, os.path.dirname(os.getcwd()), "base file-system directory for git repos"),
     ("sender", True, sender, "sender address for mails"),
     ("link", True, None, "Link to insert into mail, %s will be replaced with revision"),
     ("updateonly", False, False, "update state file only, no mails"),
@@ -308,8 +309,16 @@ def getCurrent():
     return state
 
 def getRepoName():
-    repo = os.path.basename(os.getcwd())
-    return repo[0:-4] if repo.endswith(".git") else repo
+    # Ensure gitbasedir ends with a trailing directory separator.
+    gitbasedir = os.path.join(Config.gitbasedir, '')
+
+    cwd = os.getcwd()
+    if cwd.startswith(gitbasedir):
+        repoName = cwd[len(gitbasedir):]
+    else:
+        # Fall back on old behaviour.
+        repoName = os.path.basename(cwd)
+    return repoName[0:-4] if repoName.endswith(".git") else repoName
 
 def reportHead(head):
     if Config.head_include:

--- a/git-notifier
+++ b/git-notifier
@@ -19,6 +19,17 @@ with warnings.catch_warnings():
     # Python 2.6 reports this as deprecated.
     import mimify
 
+try:
+    # Python 3
+    from configparser import ConfigParser
+    from configparser import NoSectionError
+    from configparser import NoOptionError
+except ImportError:
+    # Python 2
+    from ConfigParser import ConfigParser
+    from ConfigParser import NoSectionError
+    from ConfigParser import NoOptionError
+
 VERSION   = "0.6-11"  # Filled in automatically.
 
 Name      = "git-notifier"
@@ -26,6 +37,7 @@ CacheFile = ".%s.dat" % Name
 Separator = "\n>---------------------------------------------------------------\n"
 NoDiff    = "[nodiff]"
 NoMail    = "[nomail]"
+CfgFile   = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'git-notifier.conf')
 
 gitolite = "GL_USER" in os.environ
 
@@ -176,7 +188,7 @@ class GitConfig:
         parser = optparse.OptionParser(version=VERSION)
 
         for (name, arg, default, help) in Options:
-            defval = self._git_config(name, default)
+            defval = self._git_config(name, self._config_file(name, arg, default))
 
             if isinstance(default, int):
                 defval = int(defval)
@@ -216,6 +228,15 @@ class GitConfig:
     def _git_config(self, key, default):
         cfg = git(["config hooks.%s" % key])
         return cfg[0] if cfg else default
+
+    def _config_file(self, key, arg, default):
+        cfg = ConfigParser()
+        cfg.read(CfgFile)
+        try:
+            return cfg.get('git-notifier', key) if arg \
+                else cfg.getboolean('git-notifier', key)
+        except (NoSectionError, NoOptionError):
+            return default
 
 def log(msg):
     print >>Config.log, "%s - %s" % (time.asctime(), msg)

--- a/git-notifier
+++ b/git-notifier
@@ -360,10 +360,14 @@ def generateMailHeader(subject, rev=None):
 
         if gitolite:
             # Gitolite version.
-            repo = "ssh://%s@%s/%s" % (whoami, Config.hostname, getRepoName())
+            repo = "ssh://%u@%h/%r"
         else:
             # Standard version.
-            repo = "ssh://%s/%s" % (Config.hostname, getRepoName())
+            repo = "ssh://%h/%r"
+
+    repo = repo.replace('%u', whoami)
+    repo = repo.replace('%h', Config.hostname)
+    repo = repo.replace('%r', getRepoName())
 
     (out, fname) = makeTmp()
 

--- a/git-notifier
+++ b/git-notifier
@@ -307,6 +307,10 @@ def getCurrent():
 
     return state
 
+def getRepoName():
+    repo = os.path.basename(os.getcwd())
+    return repo[0:-4] if repo.endswith(".git") else repo
+
 def reportHead(head):
     if Config.head_include:
         return head in Config.head_include and not head in Config.head_exclude
@@ -356,13 +360,10 @@ def generateMailHeader(subject, rev=None):
 
         if gitolite:
             # Gitolite version.
-            repo = "ssh://%s@%s/%s" % (whoami, Config.hostname, os.path.basename(os.getcwd()))
+            repo = "ssh://%s@%s/%s" % (whoami, Config.hostname, getRepoName())
         else:
             # Standard version.
-            repo = "ssh://%s/%s" % (Config.hostname, os.path.basename(os.getcwd()))
-
-        if repo.endswith(".git"):
-            repo = repo[0:-4]
+            repo = "ssh://%s/%s" % (Config.hostname, getRepoName())
 
     (out, fname) = makeTmp()
 
@@ -370,8 +371,7 @@ def generateMailHeader(subject, rev=None):
     sender = Config.sender
 
     emailprefix = Config.emailprefix
-    repo_base = repo[repo.rfind("/") + 1:]
-    emailprefix = emailprefix.replace("%r", repo_base)
+    emailprefix = emailprefix.replace("%r", getRepoName())
 
     if not sender:
         if rev:
@@ -492,7 +492,7 @@ def sendChangeMail(rev, subject, heads, show_cmd, diff_cmd, stat_cmd):
 
     if Config.link:
         url = Config.link.replace("%s", rev)
-        url = url.replace("%r", os.path.basename(os.getcwd()))
+        url = url.replace("%r", getRepoName())
         print >>out, mailTag("Link", url)
 
     footer = ""

--- a/git-notifier.conf
+++ b/git-notifier.conf
@@ -1,0 +1,25 @@
+[git-notifier]
+
+# This is the git-notifier configuration file, which provides system-wide
+# default configuration values. Configuration data is taken in the following
+# order of precedence:
+#
+#  1. command-line options
+#  2. repo-specific configuration (via 'git config hooks.<option>')
+#  3. this file
+#
+# In the default configuration file shipped with git-notifier, options are
+# specified with their default value where possible, but are left commented.
+# Uncommented options override the default value.
+
+#allchanges = 
+#debug = off
+#emailprefix = [git/%r]
+#log = git-notifier.log
+#mailcmd = /usr/sbin/sendmail -t
+#maxdiffsize = 50
+#noupdate = false
+#updateonly = false
+#mergediffs = 
+#ignoreremotes = false
+#maxage = 30


### PR DESCRIPTION
Added support for specifying system-wide defaults in a config file (`git-notifier.conf` in the same directory as `git-notifier`), to avoid having to repeat `git config hooks.<config>` settings across all repos.
