### PR TITLE
Fix rev-list call for branch names containing single-quotes.

### DIFF
--- a/git-notifier
+++ b/git-notifier
@@ -6,6 +6,7 @@ import os
 import quopri
 import shutil
 import smtplib
+import string
 import socket
 import subprocess
 import sys
@@ -338,7 +339,7 @@ def getTags(state):
             state.tags[tag] = rev
 
 def getReachableRefs(state):
-    keys = ["'%s'" % k for k in state.heads.keys() + state.tags.keys()]
+    keys = ["'%s'" % k for k in [string.replace(k, '\'', '\'\"\'\"\'') for k in state.heads.keys() + state.tags.keys()]]
 
     if keys:
         for rev in git(["rev-list"] + keys):


### PR DESCRIPTION
We somehow managed to create branches having a single-quote in their name. The additional quote wasn't escaped properly, the rev-list call failed. This change should fix this issue.