### PR TITLE
Make compatible with Python-3

### DIFF
--- a/git-notifier
+++ b/git-notifier
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import getpass
+import itertools
 import optparse
 import os
 import quopri
@@ -16,12 +17,6 @@ import email.charset
 import email.header
 import email.message
 import email.utils
-import warnings
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    # Python 2.6 reports this as deprecated.
-    import mimify
 
 try:
     # Python 3
@@ -38,7 +33,7 @@ VERSION   = "0.7-17"  # Filled in automatically.
 
 Name      = "git-notifier"
 CacheFile = ".%s.dat" % Name
-Separator = "\n>---------------------------------------------------------------\n"
+Separator = "\n>---------------------------------------------------------------\n\n"
 NoDiff    = "[nodiff]"
 NoMail    = "[nomail]"
 CfgName   = "git-notifier.conf"
@@ -51,8 +46,7 @@ except KeyError:
 
 gitolite = "GL_USER" in os.environ
 
-mimify.CHARSET = 'UTF-8'
-email.charset.add_charset('utf-8', email.Charset.QP, email.Charset.QP, 'utf-8')
+email.charset.add_charset('utf-8', email.charset.QP, email.charset.QP, 'utf-8')
 
 if "LOGNAME" in os.environ:
     whoami = os.environ["LOGNAME"]
@@ -117,18 +111,18 @@ class State:
         out = open(file, "w")
 
         for (head, ref) in self.heads.items():
-            print >>out, "head", head, ref
+            out.write("head %s %s\n" % (head, ref))
 
         for (tag, ref) in self.tags.items():
-            print >>out, "tag", tag, ref
+            out.write("tag %s %s\n" % (tag, ref))
 
         for rev in self.revs:
-            print >>out, "rev", rev
+            out.write("rev %s\n" % rev)
 
         # No longer used.
         #
         # for rev in self.diffs:
-        #     print >>out, "diff", rev
+        #     out.write("diff %s\n" % rev)
 
     def readFrom(self, file):
         self.clear()
@@ -221,11 +215,11 @@ class GitConfig:
                     # parameter.
                     config.read(cfgpath[0])
             except IOError as e:
-                print >>sys.stderr, "error reading configuration file: %s" % e
+                sys.stderr.write("error reading configuration file: %s\n" % e)
                 sys.exit(1)
 
         elif cfgpath[1]:
-            print >>sys.stderr, "cannot open configuration file: %s" % cfgpath[0]
+            sys.stderr.write("cannot open configuration file: %s\n" % cfgpath[0])
             sys.exit(1)
 
         for (name, arg, default, help) in Options:
@@ -284,7 +278,7 @@ class GitConfig:
             return default
 
 def log(msg):
-    print >>Config.log, "%s - %s" % (time.asctime(), msg)
+    Config.log.write("%s - %s\n" % (time.asctime(), msg))
 
 def error(msg):
     log("Error: %s" % msg)
@@ -296,7 +290,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
 
     try:
         if Config.debug:
-            print >>sys.stderr, "> git " + args
+            sys.stderr.write("> git %s\n" % args)
     except NameError:
         # Config may not be defined yet.
         pass
@@ -304,7 +298,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
     try:
         child = subprocess.Popen("git " + args, shell=True, stdin=None, stdout=stdout_to, stderr=subprocess.PIPE)
         (stdout, stderr) = child.communicate()
-    except OSError, e:
+    except OSError as e:
         error("cannot start git: %s" % str(e))
 
     if child.returncode != 0 and stderr:
@@ -314,6 +308,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
     if stdout_to != subprocess.PIPE:
         return []
 
+    stdout = stdout.decode("utf-8")
     if not all:
         return [line.strip() for line in stdout.split("\n") if line]
     else:
@@ -338,7 +333,7 @@ def getTags(state):
             state.tags[tag] = rev
 
 def getReachableRefs(state):
-    keys = ["'%s'" % k for k in state.heads.keys() + state.tags.keys()]
+    keys = ["'%s'" % k for k in itertools.chain(state.heads.keys(), state.tags.keys())]
 
     if keys:
         for rev in git(["rev-list"] + keys):
@@ -401,9 +396,11 @@ def deleteTmps():
         smtp_session.quit()
 
 def mailTag(key, value):
-    return "%-11s: %s" % (key, value)
+    return "%-11s: %s\n" % (key, value)
 
 def encodeHeader(hdr):
+    if sys.version_info >= (3,):
+        return hdr
     try:
         hdr.decode('ascii')
     except UnicodeDecodeError:
@@ -441,7 +438,7 @@ def getRepo():
 
 def startMailBody():
     (out, fname) = makeTmp()
-    print >>out, mailTag("Repository", getRepo())
+    out.write(mailTag("Repository", getRepo()))
     return (out, fname)
 
 def generateMail(subject, body, rev, type):
@@ -511,8 +508,8 @@ def sendMail(subject, out, fname, rev=None, type=None):
     msg = generateMail(subject, open(fname).read(), rev, type)
 
     if Config.debug:
-        print msg
-        print ""
+        print(msg)
+        print("")
 
     elif Config.mailserver:
         try:
@@ -545,7 +542,7 @@ def sendMail(subject, out, fname, rev=None, type=None):
 
     else:
         stdin = subprocess.Popen(Config.mailcmd, shell=True, stdin=subprocess.PIPE).stdin
-        print >>stdin, msg
+        stdin.write(msg.encode("utf-8") + "\n".encode("utf-8"))
         stdin.close()
 
     # Wait a bit in case we're going to send more mails. Otherwise, the mails
@@ -562,8 +559,8 @@ def entryAdded(key, value, rev):
 
     (out, fname) = startMailBody()
 
-    print >>out, mailTag("New %s" % key, value)
-    print >>out, mailTag("Referencing", rev)
+    out.write(mailTag("New %s" % key, value))
+    out.write(mailTag("Referencing", rev))
 
     sendMail("%s '%s' created" % (key, value), out, fname, rev, type=key)
 
@@ -575,7 +572,7 @@ def entryDeleted(key, value):
 
     (out, fname) = startMailBody()
 
-    print >>out, mailTag("Deleted %s" % key, value)
+    out.write(mailTag("Deleted %s" % key, value))
 
     sendMail("%s '%s' deleted" % (key, value), out, fname)
 
@@ -608,12 +605,12 @@ def sendChangeMail(rev, subject, heads, show_cmd, diff_cmd, stat_cmd):
     multi = "es" if len(heads) > 1 else ""
     heads = ",".join(heads)
 
-    print >>out, mailTag("On branch%s" % multi, heads)
+    out.write(mailTag("On branch%s" % multi, heads))
 
     if Config.link:
         url = Config.link.replace("%s", rev)
         url = url.replace("%r", getRepoName())
-        print >>out, mailTag("Link", url)
+        out.write(mailTag("Link", url))
 
     footer = ""
     show = git(show_cmd)
@@ -638,27 +635,27 @@ def sendChangeMail(rev, subject, heads, show_cmd, diff_cmd, stat_cmd):
             tmp.close()
             footer = "\nDiff suppressed because of size. To see it, use:\n\n    git %s" % diff_cmd
 
-    print >>out, Separator
+    out.write(Separator)
 
     for line in git(show_cmd, all=True):
         if line == "---":
-            print >>out, Separator
+            out.write(Separator)
         else:
-            print >>out, line
+            out.write(line + "\n")
 
-    print >>out, Separator
+    out.write(Separator)
 
     if tname:
         for line in open(tname):
-            print >>out, line,
+            out.write(line)
 
-    print >>out, footer
+    out.write(footer + "\n")
 
     if Config.debug:
-        print >>out, "-- "
-        print >>out, "debug: show_cmd = git %s" % show_cmd
-        print >>out, "debug: diff_cmd = git %s" % diff_cmd
-        print >>out, "debug: stat_cmd = git %s" % stat_cmd
+        out.write("-- \n")
+        out.write("debug: show_cmd = git %s\n" % show_cmd)
+        out.write("debug: diff_cmd = git %s\n" % diff_cmd)
+        out.write("debug: stat_cmd = git %s\n" % stat_cmd)
 
     sendMail(subject, out, fname, rev)
 
@@ -757,11 +754,10 @@ def headMoved(head, path):
 
     (out, fname) = startMailBody()
 
-    print >>out, "Branch '%s' now includes:" % head
-    print >>out, ""
+    out.write("Branch '%s' now includes:\n\n" % head)
 
     for rev in path:
-        print >>out, "    ", git("show -s --pretty=oneline --abbrev-commit %s" % rev)[0]
+        out.write("    %s\n" % git("show -s --pretty=oneline --abbrev-commit %s" % rev)[0])
 
     sendMail("%s's head updated: %s" % (head, subject[0]), out, fname)
 
@@ -771,7 +767,7 @@ log("Running for %s" % os.getcwd())
 
 if Config.debug:
     for (name, arg, default, help) in Options:
-        print >>sys.stderr, "[Option %s: %s]" % (name, Config.__dict__[name])
+        sys.stderr.write("[Option %s: %s]\n" % (name, Config.__dict__[name]))
 
 cache = State()
 

--- a/git-notifier
+++ b/git-notifier
@@ -20,9 +20,14 @@ import email.utils
 
 try:
     # Python 3
-    from configparser import ConfigParser
+    import configparser
     from configparser import NoSectionError
     from configparser import NoOptionError
+
+    class ConfigParser(configparser.ConfigParser):
+        def __init__(self, *args, **kw):
+            kw['interpolation'] = None
+            super(ConfigParser, self).__init__(*args, **kw)
 except ImportError:
     # Python 2
     from ConfigParser import ConfigParser

--- a/git-notifier
+++ b/git-notifier
@@ -313,7 +313,8 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
     if stdout_to != subprocess.PIPE:
         return []
 
-    stdout = stdout.decode("utf-8")
+    if sys.version_info >= (3,):
+        stdout = stdout.decode("utf-8")
     if not all:
         return [line.strip() for line in stdout.split("\n") if line]
     else:

--- a/github-notifier
+++ b/github-notifier
@@ -15,7 +15,13 @@ try:
     from ConfigParser import ConfigParser, NoSectionError, NoOptionError
 except ImportError:
     # Python 3
-    from configparser import ConfigParser, NoSectionError, NoOptionError
+    from configparser import NoSectionError, NoOptionError
+    import configparser
+
+    class ConfigParser(configparser.ConfigParser):
+        def __init__(self, *args, **kw):
+            kw['interpolation'] = None
+            super(ConfigParser, self).__init__(*args, **kw)
 
 
 VERSION   = "0.7-17"  # Filled in automatically.

--- a/github-notifier
+++ b/github-notifier
@@ -2,7 +2,6 @@
 #
 # Needs http://jacquev6.github.io/PyGithub.
 
-import ConfigParser
 import optparse
 import time
 import os
@@ -10,6 +9,14 @@ import shutil
 import subprocess
 import sys
 import github
+
+try:
+    # Python 2
+    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
+except ImportError:
+    # Python 3
+    from configparser import ConfigParser, NoSectionError, NoOptionError
+
 
 VERSION   = "0.7-17"  # Filled in automatically.
 
@@ -22,7 +29,7 @@ Options = None
 
 def log(msg):
     assert Options
-    print >>Config.log, "%s - %s" % (time.asctime(), msg)
+    Config.log.write("%s - %s\n" % (time.asctime(), msg))
 
 def error(msg):
     log("Error: %s" % msg)
@@ -31,7 +38,7 @@ def error(msg):
 def getOption(section, key, default):
     try:
         return Config.get(section, key)
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+    except (NoSectionError, NoOptionError):
         return default
 
 DirectoryStack = []
@@ -48,13 +55,13 @@ def runCommand(args):
         args = " ".join(args)
 
     if Options.debug:
-        print >>sys.stderr, "> " + args
+        sys.stderr.write("> %s\n" % args)
 
     try:
         args = "GIT_ASKPASS=echo %s" % args
         child = subprocess.Popen(args, shell=True, stdin=None, stdout=None, stderr=None)
         (stdout, stderr) = child.communicate()
-    except OSError, e:
+    except OSError as e:
         error("cannot run command '%s': %s" % (args, e))
 
     if child.returncode != 0:
@@ -67,7 +74,7 @@ def gitClone(repo):
 
     try:
         os.makedirs(repo.path)
-    except IOError, e:
+    except IOError as e:
         error("cannot create %s: %s" % (repo.path, e))
 
     # We don't actually clone here to avoid storing the token in git's
@@ -85,7 +92,7 @@ def gitUpdate(repo):
 
     # git-notifier picks this up.
     fname = open("repo-name.dat", "w")
-    print >>fname, repo.name
+    fname.write('%s\n' % repo.name)
     fname.close()
 
     popDirectory()
@@ -123,7 +130,7 @@ def gitRepositories(rset, org = None):
     try:
         repos = [Repository(rset, org, repo.name) for repo in gh.get_user(org).get_repos()]
         repos += [Repository(rset, org, repo.name) for repo in gh.get_organization(org).get_repos()]
-    except github.GithubException, e:
+    except github.GithubException as e:
         error("GitHub exception: %s" % e._GithubException__data["message"])
 
     if not repos:
@@ -150,7 +157,7 @@ class Repository:
             return "https://github.com/%s/%s" % (self.org, self.name)
 
     def printDebug(self):
-        print >>sys.stderr, "  %s/%s (path: %s)" % (self.org, self.name, self.path)
+        sys.stderr.write("  %s/%s (path: %s)\n" % (self.org, self.name, self.path))
 
     def update(self):
         if not os.path.exists(self.path):
@@ -232,12 +239,12 @@ class RepositorySet:
             rset.update()
 
     def printDebug(self):
-        print >>sys.stderr, "Set:", self.name
-        print >>sys.stderr, "  User %s" % self.user
-        print >>sys.stderr, "  Token %s" % self.token
+        sys.stderr.write("Set:%s\n" % self.name)
+        sys.stderr.write("  User %s\n" % self.user)
+        sys.stderr.write("  Token %s\n" % self.token)
 
         for (key, value) in self.notifier_options.items():
-            print >>sys.stderr, "  Notifier: %s=%s" % (key, value)
+            sys.stderr.write("  Notifier: %s=%s\n" % (key, value))
 
         for r in self.repositories:
             r.printDebug()
@@ -258,10 +265,10 @@ if len(args) > 1:
     optparser.error("wrong number of arguments")
 
 if not os.path.exists(Options.config):
-    print >>sys.stderr, "configuration file '%s' not found" % Options.config
+    sys.stderr.write("configuration file '%s' not found\n" % Options.config)
     sys.exit(1)
 
-Config = ConfigParser.ConfigParser()
+Config = ConfigParser()
 Config.read(Options.config)
 
 if Options.debug:


### PR DESCRIPTION
Note that you'll have to escape `git(hub)-notifier.cfg` settings like `(notifier-)emailprefix = [%r]` as `%%r` under Python-3, because ConfigParser now attempts some kind of expansion otherwise.