### PR TITLE
Support for custom log file in github-notifier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -418,6 +418,9 @@ Usage
         log more verbosely and to stderr, and (2) run ``git-notifier``
         with the ``--debug`` and ``--noupdate`` options.
 
+    ``--log``
+        Specifies an alternative log file.
+
     ``--update-only``
         Updates the local clones of all repositories, but do es not run
         ``git-notifier`` for the changes. This can be helpful to catch

--- a/github-notifier
+++ b/github-notifier
@@ -15,7 +15,6 @@ VERSION   = "0.7-17"  # Filled in automatically.
 
 Name       = "github-notifier"
 ConfigFile = "./%s.cfg" % Name
-LogFile    = "%s.log" % Name
 
 Config = None
 Options = None
@@ -249,6 +248,8 @@ optparser.add_option("-c", "--config", action="store", dest="config", default=Co
                      help="specify alternative configuration file to use")
 optparser.add_option("-d", "--debug", action="store_true", dest="debug", default=False,
                      help="enable debug mode, logs to stderr")
+optparser.add_option("-l", "--log", action="store", dest="log", default="%s.log" % Name,
+                     help="specify an alternative log file to use")
 optparser.add_option("-u", "--update-only", action="store_true", dest="update_only", default=False,
                      help="update the local clones only, do not run git-notifier")
 
@@ -267,7 +268,7 @@ Config.read(Options.config)
 if Options.debug:
     Config.log = sys.stderr
 else:
-    Config.log = open(LogFile, "a")
+    Config.log = open(Options.log, "a")
 
 (basedir, fname) = os.path.split(Options.config)
 


### PR DESCRIPTION
Currently github-notifier always logs to the working directory.
However, for security reasons it's very common to have cron run
the script as an unprivileged user. In that case, if that user is
not the owner of the directory where the script lies (good
practice if we want to prevent the unprivileged user from
replacing the script itself), it won't be able to write to that
logfile.

With this commit, github-notifier gets a new [-l|--log] command
line option to allow users to use a custom logfile.