### PR TITLE
Add support for custom headers in mail messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -258,6 +258,14 @@ The options are:
     ``--mailsubjectlen <max>`` Limits subjects of generated mails to
         ``<max>`` characters. Default os no limit.
 
+    ``--mailheader-* <value>``
+        Any extra header that needs to be set in the mail message.
+        For example, ``--mailheader-X-Repo=Linux`` would result
+        in an ``x-repo: Linux`` header being added to the message.
+        Note that mail headers names are case-insentive and will be
+        converted to lowercase since both ``git-config`` and
+        Python's ``ConfigParser`` return keys in lowercase.
+
     ``--manual [rev1..]rev2``
         Mails out notifications for all revisions on the way from
         ``rev1`` to ``rev2``. If ``rev1`` is skipped, ``rev2~1`` is

--- a/git-notifier
+++ b/git-notifier
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import getpass
+import itertools
 import optparse
 import os
 import quopri
@@ -16,18 +17,17 @@ import email.charset
 import email.header
 import email.message
 import email.utils
-import warnings
-
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    # Python 2.6 reports this as deprecated.
-    import mimify
 
 try:
     # Python 3
-    from configparser import ConfigParser
+    import configparser
     from configparser import NoSectionError
     from configparser import NoOptionError
+
+    class ConfigParser(configparser.ConfigParser):
+        def __init__(self, *args, **kw):
+            kw['interpolation'] = None
+            super(ConfigParser, self).__init__(*args, **kw)
 except ImportError:
     # Python 2
     from ConfigParser import ConfigParser
@@ -38,7 +38,7 @@ VERSION   = "0.7-17"  # Filled in automatically.
 
 Name      = "git-notifier"
 CacheFile = ".%s.dat" % Name
-Separator = "\n>---------------------------------------------------------------\n"
+Separator = "\n>---------------------------------------------------------------\n\n"
 NoDiff    = "[nodiff]"
 NoMail    = "[nomail]"
 CfgName   = "git-notifier.conf"
@@ -51,8 +51,7 @@ except KeyError:
 
 gitolite = "GL_USER" in os.environ
 
-mimify.CHARSET = 'UTF-8'
-email.charset.add_charset('utf-8', email.Charset.QP, email.Charset.QP, 'utf-8')
+email.charset.add_charset('utf-8', email.charset.QP, email.charset.QP, 'utf-8')
 
 if "LOGNAME" in os.environ:
     whoami = os.environ["LOGNAME"]
@@ -117,18 +116,18 @@ class State:
         out = open(file, "w")
 
         for (head, ref) in self.heads.items():
-            print >>out, "head", head, ref
+            out.write("head %s %s\n" % (head, ref))
 
         for (tag, ref) in self.tags.items():
-            print >>out, "tag", tag, ref
+            out.write("tag %s %s\n" % (tag, ref))
 
         for rev in self.revs:
-            print >>out, "rev", rev
+            out.write("rev %s\n" % rev)
 
         # No longer used.
         #
         # for rev in self.diffs:
-        #     print >>out, "diff", rev
+        #     out.write("diff %s\n" % rev)
 
     def readFrom(self, file):
         self.clear()
@@ -221,11 +220,11 @@ class GitConfig:
                     # parameter.
                     config.read(cfgpath[0])
             except IOError as e:
-                print >>sys.stderr, "error reading configuration file: %s" % e
+                sys.stderr.write("error reading configuration file: %s\n" % e)
                 sys.exit(1)
 
         elif cfgpath[1]:
-            print >>sys.stderr, "cannot open configuration file: %s" % cfgpath[0]
+            sys.stderr.write("cannot open configuration file: %s\n" % cfgpath[0])
             sys.exit(1)
 
         for (name, arg, default, help) in Options:
@@ -284,7 +283,7 @@ class GitConfig:
             return default
 
 def log(msg):
-    print >>Config.log, "%s - %s" % (time.asctime(), msg)
+    Config.log.write("%s - %s\n" % (time.asctime(), msg))
 
 def error(msg):
     log("Error: %s" % msg)
@@ -296,7 +295,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
 
     try:
         if Config.debug:
-            print >>sys.stderr, "> git " + args
+            sys.stderr.write("> git %s\n" % args)
     except NameError:
         # Config may not be defined yet.
         pass
@@ -304,7 +303,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
     try:
         child = subprocess.Popen("git " + args, shell=True, stdin=None, stdout=stdout_to, stderr=subprocess.PIPE)
         (stdout, stderr) = child.communicate()
-    except OSError, e:
+    except OSError as e:
         error("cannot start git: %s" % str(e))
 
     if child.returncode != 0 and stderr:
@@ -314,6 +313,8 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
     if stdout_to != subprocess.PIPE:
         return []
 
+    if sys.version_info >= (3,):
+        stdout = stdout.decode("utf-8")
     if not all:
         return [line.strip() for line in stdout.split("\n") if line]
     else:
@@ -338,7 +339,7 @@ def getTags(state):
             state.tags[tag] = rev
 
 def getReachableRefs(state):
-    keys = ["'%s'" % k for k in state.heads.keys() + state.tags.keys()]
+    keys = ["'%s'" % k for k in itertools.chain(state.heads.keys(), state.tags.keys())]
 
     if keys:
         for rev in git(["rev-list"] + keys):
@@ -401,9 +402,11 @@ def deleteTmps():
         smtp_session.quit()
 
 def mailTag(key, value):
-    return "%-11s: %s" % (key, value)
+    return "%-11s: %s\n" % (key, value)
 
 def encodeHeader(hdr):
+    if sys.version_info >= (3,):
+        return hdr
     try:
         hdr.decode('ascii')
     except UnicodeDecodeError:
@@ -441,7 +444,7 @@ def getRepo():
 
 def startMailBody():
     (out, fname) = makeTmp()
-    print >>out, mailTag("Repository", getRepo())
+    out.write(mailTag("Repository", getRepo()))
     return (out, fname)
 
 def generateMail(subject, body, rev, type):
@@ -511,8 +514,8 @@ def sendMail(subject, out, fname, rev=None, type=None):
     msg = generateMail(subject, open(fname).read(), rev, type)
 
     if Config.debug:
-        print msg
-        print ""
+        print(msg)
+        print("")
 
     elif Config.mailserver:
         try:
@@ -545,7 +548,7 @@ def sendMail(subject, out, fname, rev=None, type=None):
 
     else:
         stdin = subprocess.Popen(Config.mailcmd, shell=True, stdin=subprocess.PIPE).stdin
-        print >>stdin, msg
+        stdin.write(msg.encode("utf-8") + "\n".encode("utf-8"))
         stdin.close()
 
     # Wait a bit in case we're going to send more mails. Otherwise, the mails
@@ -562,8 +565,8 @@ def entryAdded(key, value, rev):
 
     (out, fname) = startMailBody()
 
-    print >>out, mailTag("New %s" % key, value)
-    print >>out, mailTag("Referencing", rev)
+    out.write(mailTag("New %s" % key, value))
+    out.write(mailTag("Referencing", rev))
 
     sendMail("%s '%s' created" % (key, value), out, fname, rev, type=key)
 
@@ -575,7 +578,7 @@ def entryDeleted(key, value):
 
     (out, fname) = startMailBody()
 
-    print >>out, mailTag("Deleted %s" % key, value)
+    out.write(mailTag("Deleted %s" % key, value))
 
     sendMail("%s '%s' deleted" % (key, value), out, fname)
 
@@ -608,12 +611,12 @@ def sendChangeMail(rev, subject, heads, show_cmd, diff_cmd, stat_cmd):
     multi = "es" if len(heads) > 1 else ""
     heads = ",".join(heads)
 
-    print >>out, mailTag("On branch%s" % multi, heads)
+    out.write(mailTag("On branch%s" % multi, heads))
 
     if Config.link:
         url = Config.link.replace("%s", rev)
         url = url.replace("%r", getRepoName())
-        print >>out, mailTag("Link", url)
+        out.write(mailTag("Link", url))
 
     footer = ""
     show = git(show_cmd)
@@ -638,27 +641,27 @@ def sendChangeMail(rev, subject, heads, show_cmd, diff_cmd, stat_cmd):
             tmp.close()
             footer = "\nDiff suppressed because of size. To see it, use:\n\n    git %s" % diff_cmd
 
-    print >>out, Separator
+    out.write(Separator)
 
     for line in git(show_cmd, all=True):
         if line == "---":
-            print >>out, Separator
+            out.write(Separator)
         else:
-            print >>out, line
+            out.write(line + "\n")
 
-    print >>out, Separator
+    out.write(Separator)
 
     if tname:
         for line in open(tname):
-            print >>out, line,
+            out.write(line)
 
-    print >>out, footer
+    out.write(footer + "\n")
 
     if Config.debug:
-        print >>out, "-- "
-        print >>out, "debug: show_cmd = git %s" % show_cmd
-        print >>out, "debug: diff_cmd = git %s" % diff_cmd
-        print >>out, "debug: stat_cmd = git %s" % stat_cmd
+        out.write("-- \n")
+        out.write("debug: show_cmd = git %s\n" % show_cmd)
+        out.write("debug: diff_cmd = git %s\n" % diff_cmd)
+        out.write("debug: stat_cmd = git %s\n" % stat_cmd)
 
     sendMail(subject, out, fname, rev)
 
@@ -757,11 +760,10 @@ def headMoved(head, path):
 
     (out, fname) = startMailBody()
 
-    print >>out, "Branch '%s' now includes:" % head
-    print >>out, ""
+    out.write("Branch '%s' now includes:\n\n" % head)
 
     for rev in path:
-        print >>out, "    ", git("show -s --pretty=oneline --abbrev-commit %s" % rev)[0]
+        out.write("    %s\n" % git("show -s --pretty=oneline --abbrev-commit %s" % rev)[0])
 
     sendMail("%s's head updated: %s" % (head, subject[0]), out, fname)
 
@@ -771,7 +773,7 @@ log("Running for %s" % os.getcwd())
 
 if Config.debug:
     for (name, arg, default, help) in Options:
-        print >>sys.stderr, "[Option %s: %s]" % (name, Config.__dict__[name])
+        sys.stderr.write("[Option %s: %s]\n" % (name, Config.__dict__[name]))
 
 cache = State()
 

--- a/git-notifier
+++ b/git-notifier
@@ -34,14 +34,15 @@ except ImportError:
     from ConfigParser import NoSectionError
     from ConfigParser import NoOptionError
 
-VERSION   = "0.7-17"  # Filled in automatically.
+VERSION    = "0.7-17"  # Filled in automatically.
 
-Name      = "git-notifier"
-CacheFile = ".%s.dat" % Name
-Separator = "\n>---------------------------------------------------------------\n"
-NoDiff    = "[nodiff]"
-NoMail    = "[nomail]"
-CfgName   = "git-notifier.conf"
+Name       = "git-notifier"
+CacheFile  = ".%s.dat" % Name
+Separator  = "\n>---------------------------------------------------------------\n"
+NoDiff     = "[nodiff]"
+NoMail     = "[nomail]"
+CfgName    = "git-notifier.conf"
+CfgSection = "git-notifier"
 
 try:
     # 2-tuple: (name, boolean) with boolen being True if file must exist.
@@ -228,6 +229,13 @@ class GitConfig:
             print >>sys.stderr, "cannot open configuration file: %s" % cfgpath[0]
             sys.exit(1)
 
+        mailheaders_names = self._get_mailheader_names_from_config_parser(config) \
+            + self._get_mailheader_names_from_git_config() \
+            + self._get_mailheader_names_from_args(args)
+
+        for h in set(mailheaders_names):
+            Options.append([h, True, None, None])
+
         for (name, arg, default, help) in Options:
             conf_default = default
             if config:
@@ -257,6 +265,10 @@ class GitConfig:
         for (name, arg, default, help) in Options:
             self.__dict__[name] = options.__dict__[name]
 
+    def getMailHeaders(self):
+        return {k.replace("mailheader-", ""):
+                v for k, v in self.__dict__.iteritems() if k.startswith("mailheader-")}
+
     def readUsers(self):
         if self.users and os.path.exists(self.users):
             for line in open(self.users):
@@ -277,11 +289,48 @@ class GitConfig:
     def _get_from_config_parser(self, config, key, arg, default):
         try:
             if arg:
-                return config.get('git-notifier', key)
+                return config.get(CfgSection, key)
             else:
-                return config.getboolean('git-notifier', key)
+                return config.getboolean(CfgSection, key)
         except (NoSectionError, NoOptionError):
             return default
+
+    def _get_mailheader_names_from_config_parser(self, config):
+        if not config.has_section(CfgSection):
+            return []
+
+        config_items = config.items(CfgSection)
+        return [h[0] for h in config_items if h[0].startswith("mailheader-")]
+
+    def _get_mailheader_names_from_git_config(self):
+        # Not using --name-only here since it's only available on Git 2.6+.
+        git_cfgs = git(["config --list"])
+
+        mail_cfgs = []
+        if not git_cfgs:
+            return mail_cfgs
+
+        for cfg in git_cfgs:
+            if cfg.startswith("hooks.mailheader-"):
+                cfg_name = cfg.split("=")[0]
+                mail_cfgs.append(cfg_name[6:])
+
+        return mail_cfgs
+
+    def _get_mailheader_names_from_args(self, args):
+        args_headers = []
+        for i, a in enumerate(args):
+            if not a.startswith("--mailheader-"):
+                continue
+
+            # Convert the header name to lowercase (but keep value case)
+            # so the behavior is consistent with that of ConfigParser
+            # and git-config.
+            normalized_arg = a[:a.index("=")].lower() + a[a.index("="):]
+            args[i] = normalized_arg
+            args_headers.append(normalized_arg[2:normalized_arg.index("=")])
+
+        return args_headers
 
 def log(msg):
     print >>Config.log, "%s - %s" % (time.asctime(), msg)
@@ -444,6 +493,12 @@ def startMailBody():
     print >>out, mailTag("Repository", getRepo())
     return (out, fname)
 
+def addCustomHeaders(msg):
+    headers = Config.getMailHeaders()
+
+    for k, v in headers.iteritems():
+        msg.add_header(k, encodeHeader(v))
+
 def generateMail(subject, body, rev, type):
     if Config.mailsubjectlen:
         try:
@@ -500,6 +555,8 @@ def generateMail(subject, body, rev, type):
 
     msg['X-Git-Repository'] = encodeHeader(repo)
     msg['X-Mailer'] = encodeHeader('%s %s' % (Name, VERSION))
+
+    addCustomHeaders(msg)
     msg.set_payload(body)
     msg.set_charset('utf-8')
 

--- a/github-notifier
+++ b/github-notifier
@@ -2,7 +2,6 @@
 #
 # Needs http://jacquev6.github.io/PyGithub.
 
-import ConfigParser
 import optparse
 import time
 import os
@@ -10,6 +9,20 @@ import shutil
 import subprocess
 import sys
 import github
+
+try:
+    # Python 2
+    from ConfigParser import ConfigParser, NoSectionError, NoOptionError
+except ImportError:
+    # Python 3
+    from configparser import NoSectionError, NoOptionError
+    import configparser
+
+    class ConfigParser(configparser.ConfigParser):
+        def __init__(self, *args, **kw):
+            kw['interpolation'] = None
+            super(ConfigParser, self).__init__(*args, **kw)
+
 
 VERSION   = "0.7-17"  # Filled in automatically.
 
@@ -22,7 +35,7 @@ Options = None
 
 def log(msg):
     assert Options
-    print >>Config.log, "%s - %s" % (time.asctime(), msg)
+    Config.log.write("%s - %s\n" % (time.asctime(), msg))
 
 def error(msg):
     log("Error: %s" % msg)
@@ -31,7 +44,7 @@ def error(msg):
 def getOption(section, key, default):
     try:
         return Config.get(section, key)
-    except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+    except (NoSectionError, NoOptionError):
         return default
 
 DirectoryStack = []
@@ -48,13 +61,13 @@ def runCommand(args):
         args = " ".join(args)
 
     if Options.debug:
-        print >>sys.stderr, "> " + args
+        sys.stderr.write("> %s\n" % args)
 
     try:
         args = "GIT_ASKPASS=echo %s" % args
         child = subprocess.Popen(args, shell=True, stdin=None, stdout=None, stderr=None)
         (stdout, stderr) = child.communicate()
-    except OSError, e:
+    except OSError as e:
         error("cannot run command '%s': %s" % (args, e))
 
     if child.returncode != 0:
@@ -67,7 +80,7 @@ def gitClone(repo):
 
     try:
         os.makedirs(repo.path)
-    except IOError, e:
+    except IOError as e:
         error("cannot create %s: %s" % (repo.path, e))
 
     # We don't actually clone here to avoid storing the token in git's
@@ -85,7 +98,7 @@ def gitUpdate(repo):
 
     # git-notifier picks this up.
     fname = open("repo-name.dat", "w")
-    print >>fname, repo.name
+    fname.write('%s\n' % repo.name)
     fname.close()
 
     popDirectory()
@@ -123,7 +136,7 @@ def gitRepositories(rset, org = None):
     try:
         repos = [Repository(rset, org, repo.name) for repo in gh.get_user(org).get_repos()]
         repos += [Repository(rset, org, repo.name) for repo in gh.get_organization(org).get_repos()]
-    except github.GithubException, e:
+    except github.GithubException as e:
         error("GitHub exception: %s" % e._GithubException__data["message"])
 
     if not repos:
@@ -150,7 +163,7 @@ class Repository:
             return "https://github.com/%s/%s" % (self.org, self.name)
 
     def printDebug(self):
-        print >>sys.stderr, "  %s/%s (path: %s)" % (self.org, self.name, self.path)
+        sys.stderr.write("  %s/%s (path: %s)\n" % (self.org, self.name, self.path))
 
     def update(self):
         if not os.path.exists(self.path):
@@ -232,12 +245,12 @@ class RepositorySet:
             rset.update()
 
     def printDebug(self):
-        print >>sys.stderr, "Set:", self.name
-        print >>sys.stderr, "  User %s" % self.user
-        print >>sys.stderr, "  Token %s" % self.token
+        sys.stderr.write("Set:%s\n" % self.name)
+        sys.stderr.write("  User %s\n" % self.user)
+        sys.stderr.write("  Token %s\n" % self.token)
 
         for (key, value) in self.notifier_options.items():
-            print >>sys.stderr, "  Notifier: %s=%s" % (key, value)
+            sys.stderr.write("  Notifier: %s=%s\n" % (key, value))
 
         for r in self.repositories:
             r.printDebug()
@@ -258,10 +271,10 @@ if len(args) > 1:
     optparser.error("wrong number of arguments")
 
 if not os.path.exists(Options.config):
-    print >>sys.stderr, "configuration file '%s' not found" % Options.config
+    sys.stderr.write("configuration file '%s' not found\n" % Options.config)
     sys.exit(1)
 
-Config = ConfigParser.ConfigParser()
+Config = ConfigParser()
 Config.read(Options.config)
 
 if Options.debug:


### PR DESCRIPTION
Currently there's no way to add custom headers in the e-mail
messages sent by git-notifier.

This commit adds support for custom headers added through either
command line options, repository configuration and the .conf file.

Since the options parser doesn't support flexible options (i.e.
those not defined in its configuration), we need to get all the
custom mail headers *before* parsing the options, and transform
them into fixed options by adding them to the Options object, so
the parser can run normally. This also allows us to keep the
same configuration precedence as before.