### PR TITLE
Remove shell=True from git-notifier and github-notifier

### DIFF
--- a/git-notifier
+++ b/git-notifier
@@ -5,6 +5,7 @@ import itertools
 import optparse
 import os
 import quopri
+import shlex
 import shutil
 import smtplib
 import string
@@ -44,6 +45,13 @@ NoDiff     = "[nodiff]"
 NoMail     = "[nomail]"
 CfgName    = "git-notifier.conf"
 CfgSection = "git-notifier"
+
+try:
+    # Find Git binary in a cross-platform way
+    # One-liner based on https://stackoverflow.com/a/28909933/2883579
+    GIT_BINARY = next(os.path.join(path, "git") for path in os.environ["PATH"].split(os.pathsep) if os.access(os.path.join(path, "git"), os.X_OK))
+except StopIteration:
+    raise RuntimeError("Git binary not found in PATH")
 
 try:
     # 2-tuple: (name, boolean) with boolen being True if file must exist.
@@ -348,8 +356,12 @@ def error(msg):
     sys.exit(1)
 
 def git(args, stdout_to=subprocess.PIPE, all=False):
+    # Even though we'll split again later, we need to turn a list/tuple into a string
+    # because in some cases one element of the list has more than a single argument.
     if isinstance(args, tuple) or isinstance(args, list):
         args = " ".join(args)
+
+    args = shlex.split(args)
 
     try:
         if Config.debug:
@@ -359,7 +371,7 @@ def git(args, stdout_to=subprocess.PIPE, all=False):
         pass
 
     try:
-        child = subprocess.Popen("git " + args, shell=True, stdin=None, stdout=stdout_to, stderr=subprocess.PIPE)
+        child = subprocess.Popen([GIT_BINARY] + args, stdin=None, stdout=stdout_to, stderr=subprocess.PIPE)
         (stdout, stderr) = child.communicate()
     except OSError as e:
         error("cannot start git: %s" % str(e))

--- a/github-notifier
+++ b/github-notifier
@@ -26,6 +26,13 @@ except ImportError:
 
 VERSION   = "0.7-35"  # Filled in automatically.
 
+try:
+    # Find Git binary in a cross-platform way
+    # One-liner based on https://stackoverflow.com/a/28909933/2883579
+    GIT_BINARY = next(os.path.join(path, "git") for path in os.environ["PATH"].split(os.pathsep) if os.access(os.path.join(path, "git"), os.X_OK))
+except StopIteration:
+    raise RuntimeError("Git binary not found in PATH")
+
 Name       = "github-notifier"
 ConfigFile = "./%s.cfg" % Name
 
@@ -55,19 +62,17 @@ def pushDirectory(dir):
 def popDirectory():
     os.chdir(DirectoryStack.pop())
 
-def runCommand(args):
-    if isinstance(args, tuple) or isinstance(args, list):
-        args = " ".join(args)
+def runCommand(args, stdout=None, stderr=None):
+    environment = { "PATH": os.environ["PATH"], "GIT_ASKPASS": "echo" }
 
     if Options.debug:
-        sys.stderr.write("> %s\n" % args)
+        sys.stderr.write("> %s\n" % (" ".join(args)))
 
     try:
-        args = "GIT_ASKPASS=echo %s" % args
-        child = subprocess.Popen(args, shell=True, stdin=None, stdout=None, stderr=None)
+        child = subprocess.Popen(args, stdin=None, stdout=stdout, stderr=stderr, env=environment)
         (stdout, stderr) = child.communicate()
     except OSError as e:
-        error("cannot run command '%s': %s" % (args, e))
+        error("cannot run command '%s': %s" % (" ".join(args), e))
 
     if child.returncode != 0:
         error("command failed with exit code %d" % child.returncode)
@@ -90,10 +95,10 @@ def gitUpdate(repo):
     log("updating %s" % repo)
 
     pushDirectory(repo.path)
-    runCommand("git --bare init --quiet")
-    runCommand("git --bare fetch --prune --quiet %s +refs/heads/*:refs/heads/*" % repo.url(True))
-    runCommand("git --bare fetch --prune --quiet %s +refs/tags/*:refs/tags/*" % repo.url(True))
-    runCommand("git remote update >/dev/null 2>&1")
+    runCommand([GIT_BINARY, "--bare", "init", "--quiet"])
+    runCommand([GIT_BINARY, "--bare", "fetch", "--prune", "--quiet", repo.url(True), "+refs/heads/*:refs/heads/*"])
+    runCommand([GIT_BINARY, "--bare", "fetch", "--prune", "--quiet", repo.url(True), "+refs/tags/*:refs/tags/*"])
+    runCommand([GIT_BINARY, "remote", "update"], stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 
     # git-notifier picks this up.
     fname = open("repo-name.dat", "w")
@@ -136,10 +141,9 @@ def runNotifier(repo):
                 opts += ["--%s" % key]
 
     gn = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), "git-notifier"))
-    cmd = "%s %s" % (gn, " ".join(opts))
 
     pushDirectory(repo.path)
-    runCommand(cmd)
+    runCommand([gn] + opts)
     popDirectory()
 
 def gitRepositories(rset, gh, org = None):


### PR DESCRIPTION
Using shell=True is considered a security hazard and is only
needed when we need variable expansion or glob patterns. By
manually looking for the Git binary in the PATH variable it was
possible to completely remove it from git-notifier and
github-notifier. It was only kept when running mailcmd since that
is specifically a shell command.