### PR TITLE
Support github wiki repositories

### DIFF
--- a/github-notifier
+++ b/github-notifier
@@ -244,7 +244,8 @@ class RepositorySet:
             if name == "*":
                 srepos = gitRepositories(self, gh, org)
             else:
-                priv = gh.get_repo(org + '/' + name).private
+                gh_name = name[:-5] if name.endswith('.wiki') else name
+                priv = gh.get_repo(org + '/' + gh_name).private
                 srepos = [Repository(self, org, name, priv)]
 
             for repo in srepos:


### PR DESCRIPTION
GitHub wikis can be cloned as git repositories, by adding `.wiki` to the
repository name:
https://help.github.com/en/articles/adding-or-editing-wiki-pages#cloning-wikis-to-your-computer

However, the GitHub `repo` API apparently has been changed at some
point, and does not know about these wiki-repos anymore. But for
determining private status we can instead ask about the "parent"
repository instead. See https://github.com/github/hub/issues/1172#issuecomment-238096678
for an analoguous case.